### PR TITLE
Fix SIGSEGV when compiling llvm_mode with Clang > 6.0

### DIFF
--- a/llvm_mode/Makefile
+++ b/llvm_mode/Makefile
@@ -58,7 +58,7 @@ ifeq "$(origin CC)" "default"
 endif
 
 ifndef AFL_TRACE_PC
-  PROGS      = ../afl-clang-fast ../afl-llvm-pass.so ../afl-llvm-rt.o ../afl-llvm-rt-32.o ../afl-llvm-rt-64.o
+  PROGS      = ../afl-clang-fast ../afl-llvm-pass.so ../afl-catch-dlclose.so ../afl-llvm-rt.o ../afl-llvm-rt-32.o ../afl-llvm-rt-64.o
 else
   PROGS      = ../afl-clang-fast ../afl-llvm-rt.o ../afl-llvm-rt-32.o ../afl-llvm-rt-64.o
 endif
@@ -84,6 +84,9 @@ endif
 
 ../afl-llvm-pass.so: afl-llvm-pass.so.cc | test_deps
 	$(CXX) $(CLANG_CFL) -shared $< -o $@ $(CLANG_LFL)
+
+../afl-catch-dlclose.so: afl-catch-dlclose.so.c | test_deps
+	$(CC) $(CFLAGS) -fPIC -shared $< -o $@
 
 ../afl-llvm-rt.o: afl-llvm-rt.o.c | test_deps
 	$(CC) $(CFLAGS) -fPIC -c $< -o $@

--- a/llvm_mode/afl-catch-dlclose.so.c
+++ b/llvm_mode/afl-catch-dlclose.so.c
@@ -1,0 +1,2 @@
+int dlclose(void *handle) { return 0; }
+

--- a/llvm_mode/afl-clang-fast.c
+++ b/llvm_mode/afl-clang-fast.c
@@ -349,6 +349,8 @@ int main(int argc, char** argv) {
 
   edit_params(argc, argv);
 
+  setenv("LD_PRELOAD", alloc_printf("%s/afl-catch-dlclose.so", obj_path), 1);
+
   execvp(cc_params[0], (char**)cc_params);
 
   FATAL("Oops, failed to execute '%s' - check your PATH", cc_params[0]);


### PR DESCRIPTION
Successfully tested with Clang 8

Reference:
https://bugs.llvm.org/show_bug.cgi?id=39321 